### PR TITLE
Catch error case when stateTexts is embedded in error dict #42

### DIFF
--- a/custom_components/flexit/models.py
+++ b/custom_components/flexit/models.py
@@ -364,5 +364,9 @@ class FlexitSensorsResponseStatus:
         """Transform response to FlexitSensorsResponseStatus."""
 
         LOGGER.debug("FlexitSensorsResponseStatus=%s", data)
+        if "stateTexts" in data:
+            stateTexts = data["stateTexts"]
+        elif "errorClass" in data:
+            stateTexts = data["error"]["stateTexts"]
 
-        return FlexitSensorsResponseStatus(stateTexts=data["stateTexts"])
+        return FlexitSensorsResponseStatus(stateTexts=stateTexts)


### PR DESCRIPTION
Suggested fix for the key error that occurs when there is an out of bounds error report